### PR TITLE
change inline commands limits to 8

### DIFF
--- a/src/main/kotlin/kz/btsd/messenger/bot/api/validation/InlineCommandTableSize.kt
+++ b/src/main/kotlin/kz/btsd/messenger/bot/api/validation/InlineCommandTableSize.kt
@@ -17,8 +17,8 @@ annotation class InlineCommandTableSize(
     val payload: Array<KClass<out Any>> = []
 )
 
-const val MAX_INLINE_CMD_ROWS = 25
-const val MAX_INLINE_CMD_ROW_SIZE = 10
+const val MAX_INLINE_CMD_ROWS = 8
+const val MAX_INLINE_CMD_ROW_SIZE = 8
 
 class InlineCommandTableValidator : ConstraintValidator<InlineCommandTableSize, List<List<InlineCommand>>> {
     override fun isValid(value: List<List<InlineCommand>>?, context: ConstraintValidatorContext?): Boolean {

--- a/src/main/kotlin/kz/btsd/messenger/bot/api/validation/InlineCommandsSize.kt
+++ b/src/main/kotlin/kz/btsd/messenger/bot/api/validation/InlineCommandsSize.kt
@@ -6,13 +6,13 @@ import javax.validation.constraints.Size
 import kotlin.reflect.KClass
 
 @MustBeDocumented
-@Size(max = 25)
+@Size(max = MAX_INLINE_CMD_ROWS)
 @ReportAsSingleViolation
 @Constraint(validatedBy = [])
 @Target(AnnotationTarget.PROPERTY_GETTER)
 annotation class InlineCommandsSize(
     val attributeName: String = "inlineCommands",
-    val message: String = "Number of {attributeName} must me less than 25, recommended number is 3",
+    val message: String = "Number of {attributeName} must me <= 8, recommended number is 3",
     val groups: Array<KClass<out Any>> = [],
     val payload: Array<KClass<out Any>> = []
 )

--- a/src/test/kotlin/kz/btsd/messenger/bot/api/helpers/Util.kt
+++ b/src/test/kotlin/kz/btsd/messenger/bot/api/helpers/Util.kt
@@ -45,7 +45,7 @@ internal fun invalidEditMessage() =
     validEditMessage().copy(messageId = "id") to TimeUuid::class
 
 internal fun validInlineCommandTable() = List(MAX_INLINE_CMD_ROWS) { List(MAX_INLINE_CMD_ROW_SIZE) { validInlineCommand() } }
-internal fun validInlineCommands() = List(25) { validInlineCommand() }
+internal fun validInlineCommands() = List(8) { validInlineCommand() }
 
 internal fun validEditMessage() = EditMessage(
     messageId = timeUuid(),

--- a/src/test/kotlin/kz/btsd/messenger/bot/api/model/command/EditMessageTest.kt
+++ b/src/test/kotlin/kz/btsd/messenger/bot/api/model/command/EditMessageTest.kt
@@ -47,21 +47,21 @@ internal class EditMessageTest : ValidatorTest() {
     }
 
     @Test
-    fun `max size of inline commands is 25`() {
+    fun `max size of inline commands is 8`() {
         message().copy(
-            inlineCommands = List(26) { validInlineCommand() }
+            inlineCommands = List(9) { validInlineCommand() }
         ).violates(InlineCommandsSize::class)
     }
 
     @Test
-    fun `max number of inline rows is 25`() {
-        val rows = List(26) { listOf(validInlineCommand()) }
+    fun `max number of inline rows is 8`() {
+        val rows = List(9) { listOf(validInlineCommand()) }
         message().copy(inlineCommandRows = rows).violates(InlineCommandTableSize::class)
     }
 
     @Test
-    fun `max size of inline rows is 10`() {
-        val rows = listOf(List(11) { validInlineCommand() })
+    fun `max size of inline row is 8`() {
+        val rows = listOf(List(9) { validInlineCommand() })
         message().copy(inlineCommandRows = rows).violates(InlineCommandTableSize::class)
     }
 
@@ -82,7 +82,7 @@ internal class EditMessageTest : ValidatorTest() {
     @Test
     fun `valid message`() {
         message().copy(
-            inlineCommands = List(25) { validInlineCommand() },
+            inlineCommands = List(8) { validInlineCommand() },
             content = 'c'.duplicate(4096),
             mediaList = List(100) { validInputMedia() }
         ).noViolations()

--- a/src/test/kotlin/kz/btsd/messenger/bot/api/model/command/SendMessageTest.kt
+++ b/src/test/kotlin/kz/btsd/messenger/bot/api/model/command/SendMessageTest.kt
@@ -59,23 +59,23 @@ class SendMessageTest : ValidatorTest() {
     }
 
     @Test
-    fun `max size of inline commands is 25`() {
+    fun `max size of inline commands is 8`() {
         message().copy(
-            inlineCommands = List(26) { validInlineCommand() }
+            inlineCommands = List(9) { validInlineCommand() }
         ).violates(InlineCommandsSize::class)
     }
 
     @Test
-    fun `max number of inline rows is 25`() {
-        val rows = List(26) { listOf(validInlineCommand()) }
+    fun `max number of inline rows is 8`() {
+        val rows = List(9) { listOf(validInlineCommand()) }
         message().copy(
             inlineCommandRows = rows
         ).violates(InlineCommandTableSize::class)
     }
 
     @Test
-    fun `max size of inline rows is 10`() {
-        val rows = listOf(List(11) { validInlineCommand() })
+    fun `max size of inline rows is 8`() {
+        val rows = listOf(List(9) { validInlineCommand() })
         message().copy(
             inlineCommandRows = rows
         ).violates(InlineCommandTableSize::class)


### PR DESCRIPTION
## Inline commands limit

* Changed limit of inline command list to 8.
* Changed maximum size of inline command table to 8x8.

Reviewers:
* @navi89mai
* @mustafin
* @vseko
